### PR TITLE
ドキュメント: PR に Issue 参照を必須化

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,4 +30,3 @@ API キーや機密 URL は `.env` または Tauri の環境読み込み機構�
 - 出力は日本語で簡潔に。
 - GitHub の Pull Request 説明・タイトルは必ず日本語で記載する。
 - Issue を解決する PR を作成する場合は、PR 本文に該当 Issue を参照（`Closes #<number>` など）として必ず記載する。
-- GitHub の Pull Request 説明・タイトルは必ず日本語で記載する。


### PR DESCRIPTION
## 概要
- AGENTS.md に「Issue を解決する PR では本文に Issue 参照（例: `Closes #1`）を必ず含める」ルールを追記しました
- 既存の「PR は日本語で書く」ルールとあわせてコミット

## テスト
- なし（ドキュメントのみ）
