### PR TITLE
ドメイン: Snippet 型を定義

### DIFF
--- a/src/core/domain/snippet/entities/index.ts
+++ b/src/core/domain/snippet/entities/index.ts
@@ -1,5 +1,19 @@
 /**
- * Snippet エンティティや関連構造体をここに定義する。
- * Issue #3 以降で実データ構造を実装予定。
+ * Snippet エンティティ定義。
+ * docs/design.md の要件に沿って UI で必要なフィールドをすべて含める。
  */
-export {}
+export type Snippet = {
+  id: string
+  title: string
+  body: string
+  shortcut?: string | null
+  description?: string | null
+  tags: string[]
+  language?: string | null
+  isFavorite: boolean
+  usageCount: number
+  lastUsedAt?: Date | null
+  libraryId: string
+  createdAt: Date
+  updatedAt: Date
+}


### PR DESCRIPTION
## 概要
- `src/core/domain/snippet/entities/index.ts` に docs/design.md 準拠の `Snippet` 型を定義
- shortcut / usageCount / lastUsedAt など UI 要件のフィールドも含めて再エクスポート

## テスト
- なし（型定義のみ）

Closes #3
