### PR TITLE
ドメイン: 識別子型エイリアスを追加

### DIFF
--- a/src/core/domain/snippet/domain-values/index.ts
+++ b/src/core/domain/snippet/domain-values/index.ts
@@ -1,5 +1,7 @@
 /**
- * SnippetId や TagName など、ドメイン上の値オブジェクトをここで管理する。
- * 具体的な実装は後続 Issue (#4 など) で追加する。
+ * ドメイン層で使い回す識別子・タグなどのプリミティブ型。
+ * それぞれ string を直接扱うより、値の意味を型名で明示できるようにする。
  */
-export {}
+export type SnippetId = string
+export type LibraryId = string
+export type TagName = string

--- a/src/core/domain/snippet/entities/index.ts
+++ b/src/core/domain/snippet/entities/index.ts
@@ -1,19 +1,21 @@
+import type { LibraryId, SnippetId, TagName } from '../domain-values'
+
 /**
  * Snippet エンティティ定義。
  * docs/design.md の要件に沿って UI で必要なフィールドをすべて含める。
  */
 export type Snippet = {
-  id: string
+  id: SnippetId
   title: string
   body: string
   shortcut?: string | null
   description?: string | null
-  tags: string[]
+  tags: TagName[]
   language?: string | null
   isFavorite: boolean
   usageCount: number
   lastUsedAt?: Date | null
-  libraryId: string
+  libraryId: LibraryId
   createdAt: Date
   updatedAt: Date
 }


### PR DESCRIPTION
## 概要
- `SnippetId` / `LibraryId` / `TagName` の型エイリアスを `domain-values` に定義
- `Snippet` エンティティで上記型を使用し、ライブラリ / タグ識別子の意味を明確化

## テスト
- なし（型定義のみ）

Closes #4
