### PR TITLE
ドメイン: SnippetLibrary 型を実装

### DIFF
--- a/src/core/domain/snippet/entities/index.ts
+++ b/src/core/domain/snippet/entities/index.ts
@@ -19,3 +19,13 @@ export type Snippet = {
   createdAt: Date
   updatedAt: Date
 }
+
+export type LibraryCategory = 'PERSONAL' | 'TEAM' | 'PROJECT'
+
+export type SnippetLibrary = {
+  id: LibraryId
+  name: string
+  description?: string | null
+  isReadOnly: boolean
+  category: LibraryCategory
+}


### PR DESCRIPTION
## 概要
- `LibraryCategory`（PERSONAL / TEAM / PROJECT）を定義
- `SnippetLibrary` に `id`/`name`/`description`/`isReadOnly`/`category` を実装
- 既存の `LibraryId` 型エイリアスを利用

## テスト
- なし（型定義のみ）

Closes #8
