### PR TITLE
ドメイン: UserPreferences 型を追加

### DIFF
--- a/src/core/domain/snippet/entities/index.ts
+++ b/src/core/domain/snippet/entities/index.ts
@@ -29,3 +29,14 @@ export type SnippetLibrary = {
   isReadOnly: boolean
   category: LibraryCategory
 }
+
+export type ThemePreference = 'light' | 'dark' | 'system'
+
+/**
+ * 将来的な UI 設定を想定したプレースホルダ。
+ */
+export type UserPreferences = {
+  defaultLibraryId: LibraryId
+  theme: ThemePreference
+  globalShortcut?: string | null
+}


### PR DESCRIPTION
## 概要
- `ThemePreference` と `UserPreferences` を定義し、`defaultLibraryId`/`theme`/`globalShortcut` を保持できるようにしました
- 既存の `LibraryId` 型を利用し、将来の設定ユースケースへ備えています

## テスト
- なし（型定義のみ）

Closes #9
