### PR TITLE
ドメイン: ライブラリアダプタのインターフェースを追加

### DIFF
--- a/src/core/domain/snippet/ports/index.ts
+++ b/src/core/domain/snippet/ports/index.ts
@@ -1,4 +1,4 @@
-import type { Snippet } from '../entities'
+import type { Snippet, SnippetLibrary } from '../entities'
 import type { SnippetId } from '../domain-values'
 
 /**
@@ -10,4 +10,11 @@ export interface SnippetDataAccessAdapter {
   getById(id: SnippetId): Promise<Snippet | null>
   save(snippet: Snippet): Promise<void>
   delete(id: SnippetId): Promise<void>
+}
+
+/**
+ * ライブラリメタデータ（Personal / Team 等）を取得するためのアダプタ。
+ */
+export interface SnippetLibraryDataAccessAdapter {
+  getLibraries(): Promise<SnippetLibrary[]>
 }


### PR DESCRIPTION
## 概要
- `SnippetLibraryDataAccessAdapter` を `ports` に追加し、ライブラリメタデータ取得の抽象化を用意
- 既存の `SnippetLibrary` 型を利用して Personal / Team などの一覧を返すメソッドを定義

## テスト
- なし（インターフェースのみ）

Closes #11
