### PR TITLE
chore: PR向けのCIを整備

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,15 @@ jobs:
       - uses: actions/checkout@v4
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
+      - name: Install Linux dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libgtk-3-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            patchelf
       - uses: actions/setup-node@v4
         with:
           node-version: '22'


### PR DESCRIPTION
## 概要
- PR/`main` 向けに Node と Rust の依存をセットアップする GitHub Actions を追加
- `npm ci` + `npm run build` で React 側のビルドを確認
- `cargo test --locked` で `src-tauri` のビルド/テストも自動化し、#60 などの PR で差分チェックを行えるようにする

## テスト
- [x] npm run build
- [x] (src-tauri) cargo test