### PR TITLE
feat: GetTopSnippetsForEmptyQueryUseCase を追加

### DIFF
--- a/src/core/usecases/snippet/getTopSnippetsForEmptyQueryUseCase.ts
+++ b/src/core/usecases/snippet/getTopSnippetsForEmptyQueryUseCase.ts
@@ -1,0 +1,43 @@
+import type {
+  LibraryId,
+  SnippetDataAccessAdapter,
+  TagName,
+} from '../../domain/snippet'
+import type { SearchSnippetsUseCaseOutput } from './searchSnippetsUseCase'
+import {
+  buildDefaultEmptyQueryResults,
+  filterSnippetsByConditions,
+} from './searchSnippetsUseCase'
+
+export type GetTopSnippetsForEmptyQueryUseCaseInput = {
+  libraryIds?: LibraryId[]
+  tags?: TagName[]
+  limit?: number
+}
+
+export type GetTopSnippetsForEmptyQueryUseCaseDependencies = {
+  snippetGateway: SnippetDataAccessAdapter
+  now?: () => Date
+}
+
+/**
+ * 空クエリ時に表示する候補（お気に入り + 最近利用）を算出するユースケース。
+ * `SearchSnippetsUseCase` の `emptyQueryStrategy` として委譲できるよう独立させている。
+ */
+export class GetTopSnippetsForEmptyQueryUseCase {
+  private readonly snippetGateway: SnippetDataAccessAdapter
+  private readonly now: () => Date
+
+  constructor(deps: GetTopSnippetsForEmptyQueryUseCaseDependencies) {
+    this.snippetGateway = deps.snippetGateway
+    this.now = deps.now ?? (() => new Date())
+  }
+
+  async execute(
+    input: GetTopSnippetsForEmptyQueryUseCaseInput
+  ): Promise<SearchSnippetsUseCaseOutput> {
+    const snippets = await this.snippetGateway.getAll()
+    const filtered = filterSnippetsByConditions(snippets, input.libraryIds, input.tags)
+    return buildDefaultEmptyQueryResults({ snippets: filtered, now: this.now, limit: input.limit })
+  }
+}

--- a/src/core/usecases/snippet/index.ts
+++ b/src/core/usecases/snippet/index.ts
@@ -1,2 +1,3 @@
 export * from './copySnippetUseCase'
 export * from './searchSnippetsUseCase'
+export * from './getTopSnippetsForEmptyQueryUseCase'

--- a/src/core/usecases/snippet/searchSnippetsUseCase.ts
+++ b/src/core/usecases/snippet/searchSnippetsUseCase.ts
@@ -5,7 +5,7 @@ import type {
   TagName,
 } from '../../domain/snippet'
 
-const SCORE = {
+export const SEARCH_SNIPPET_SCORING = {
   shortcutExact: 100,
   titlePrefix: 60,
   titlePartial: 30,
@@ -15,6 +15,8 @@ const SCORE = {
   usageNormalized: 10,
   recencyNormalized: 15,
 } as const
+
+const SCORE = SEARCH_SNIPPET_SCORING
 
 export type SearchSnippetsUseCaseInput = {
   query: string
@@ -55,17 +57,17 @@ export class SearchSnippetsUseCase {
   async execute(input: SearchSnippetsUseCaseInput): Promise<SearchSnippetsUseCaseOutput> {
     const normalizedQuery = input.query.trim().toLowerCase()
     const snippets = await this.snippetGateway.getAll()
-    const filtered = this.filterByConditions(snippets, input.libraryIds, input.tags)
+    const filtered = filterSnippetsByConditions(snippets, input.libraryIds, input.tags)
 
     if (!normalizedQuery) {
       if (this.emptyQueryStrategy) {
         return this.emptyQueryStrategy(input)
       }
-      return this.buildDefaultResults(filtered, input.limit)
+      return buildDefaultEmptyQueryResults({ snippets: filtered, now: this.now, limit: input.limit })
     }
 
-    const usageNormalizer = this.createUsageNormalizer(filtered)
-    const recencyNormalizer = this.createRecencyNormalizer(filtered)
+    const usageNormalizer = createUsageNormalizer(filtered)
+    const recencyNormalizer = createRecencyNormalizer(filtered, this.now)
 
     const scored = filtered
       .map(snippet => ({
@@ -78,38 +80,13 @@ export class SearchSnippetsUseCase {
         }),
       }))
       .filter(result => result.score > 0)
-      .sort((a, b) => this.compareResults(a, b))
+      .sort(compareSearchSnippetResults)
 
     if (input.limit && input.limit > 0) {
       return scored.slice(0, input.limit)
     }
 
     return scored
-  }
-
-  private filterByConditions(
-    snippets: Snippet[],
-    libraryIds?: LibraryId[],
-    tags?: TagName[]
-  ): Snippet[] {
-    let result = snippets
-
-    if (libraryIds && libraryIds.length > 0) {
-      const librarySet = new Set(libraryIds)
-      result = result.filter(snippet => librarySet.has(snippet.libraryId))
-    }
-
-    if (tags && tags.length > 0) {
-      const normalizedTags = tags.map(tag => tag.trim().toLowerCase()).filter(Boolean)
-      if (normalizedTags.length > 0) {
-        result = result.filter(snippet => {
-          const snippetTags = snippet.tags.map(tag => tag.toLowerCase())
-          return normalizedTags.every(tag => snippetTags.includes(tag))
-        })
-      }
-    }
-
-    return result
   }
 
   private calculateScore(input: {
@@ -153,77 +130,106 @@ export class SearchSnippetsUseCase {
 
     return score
   }
+}
 
-  private createUsageNormalizer(snippets: Snippet[]): UsageNormalizer {
-    const maxUsage = snippets.reduce((max, snippet) => Math.max(max, snippet.usageCount), 0)
-    if (maxUsage <= 0) {
-      return () => 0
-    }
-    return usageCount => (usageCount / maxUsage) * SCORE.usageNormalized
+export function filterSnippetsByConditions(
+  snippets: Snippet[],
+  libraryIds?: LibraryId[],
+  tags?: TagName[]
+): Snippet[] {
+  let result = snippets
+
+  if (libraryIds && libraryIds.length > 0) {
+    const librarySet = new Set(libraryIds)
+    result = result.filter(snippet => librarySet.has(snippet.libraryId))
   }
 
-  private createRecencyNormalizer(snippets: Snippet[]): RecencyNormalizer {
-    const hasRecencyData = snippets.some(snippet => snippet.lastUsedAt)
-    if (!hasRecencyData) {
-      return () => 0
-    }
-
-    const now = this.now().getTime()
-    const recencyWindowMs = 1000 * 60 * 60 * 24 * 30 // 30 日分をボーナス対象とする
-
-    return timestamp => {
-      if (!timestamp) return 0
-      const diff = now - timestamp.getTime()
-      if (diff <= 0) return SCORE.recencyNormalized
-      if (diff >= recencyWindowMs) return 0
-      return ((recencyWindowMs - diff) / recencyWindowMs) * SCORE.recencyNormalized
-    }
-  }
-
-  private buildDefaultResults(
-    snippets: Snippet[],
-    limit?: number
-  ): SearchSnippetsUseCaseOutput {
-    const usageNormalizer = this.createUsageNormalizer(snippets)
-    const recencyNormalizer = this.createRecencyNormalizer(snippets)
-
-    const scored = snippets
-      .map(snippet => {
-        let score = 0
-        if (snippet.isFavorite) {
-          score += SCORE.favoriteBonus
-        }
-        score += usageNormalizer(snippet.usageCount)
-        score += recencyNormalizer(snippet.lastUsedAt)
-        return { snippet, score }
+  if (tags && tags.length > 0) {
+    const normalizedTags = tags.map(tag => tag.trim().toLowerCase()).filter(Boolean)
+    if (normalizedTags.length > 0) {
+      result = result.filter(snippet => {
+        const snippetTags = snippet.tags.map(tag => tag.toLowerCase())
+        return normalizedTags.every(tag => snippetTags.includes(tag))
       })
-      .sort((a, b) => this.compareResults(a, b))
-
-    if (limit && limit > 0) {
-      return scored.slice(0, limit)
     }
-    return scored
   }
 
-  private compareResults(a: SearchSnippetsUseCaseResult, b: SearchSnippetsUseCaseResult): number {
-    if (b.score !== a.score) {
-      return b.score - a.score
-    }
+  return result
+}
 
-    if (a.snippet.isFavorite !== b.snippet.isFavorite) {
-      return a.snippet.isFavorite ? -1 : 1
-    }
-
-    if (b.snippet.usageCount !== a.snippet.usageCount) {
-      return b.snippet.usageCount - a.snippet.usageCount
-    }
-
-    const aTime = a.snippet.updatedAt.getTime()
-    const bTime = b.snippet.updatedAt.getTime()
-    if (bTime !== aTime) {
-      return bTime - aTime
-    }
-
-    return a.snippet.title.localeCompare(b.snippet.title)
+const createUsageNormalizer = (snippets: Snippet[]): UsageNormalizer => {
+  const maxUsage = snippets.reduce((max, snippet) => Math.max(max, snippet.usageCount), 0)
+  if (maxUsage <= 0) {
+    return () => 0
   }
+  return usageCount => (usageCount / maxUsage) * SCORE.usageNormalized
+}
+
+const createRecencyNormalizer = (snippets: Snippet[], now: () => Date): RecencyNormalizer => {
+  const hasRecencyData = snippets.some(snippet => snippet.lastUsedAt)
+  if (!hasRecencyData) {
+    return () => 0
+  }
+
+  const currentTime = now().getTime()
+  const recencyWindowMs = 1000 * 60 * 60 * 24 * 30 // 30 日分をボーナス対象
+
+  return timestamp => {
+    if (!timestamp) return 0
+    const diff = currentTime - timestamp.getTime()
+    if (diff <= 0) return SCORE.recencyNormalized
+    if (diff >= recencyWindowMs) return 0
+    return ((recencyWindowMs - diff) / recencyWindowMs) * SCORE.recencyNormalized
+  }
+}
+
+export function buildDefaultEmptyQueryResults(input: {
+  snippets: Snippet[]
+  now: () => Date
+  limit?: number
+}): SearchSnippetsUseCaseOutput {
+  const usageNormalizer = createUsageNormalizer(input.snippets)
+  const recencyNormalizer = createRecencyNormalizer(input.snippets, input.now)
+
+  const scored = input.snippets
+    .map(snippet => {
+      let score = 0
+      if (snippet.isFavorite) {
+        score += SCORE.favoriteBonus
+      }
+      score += usageNormalizer(snippet.usageCount)
+      score += recencyNormalizer(snippet.lastUsedAt)
+      return { snippet, score }
+    })
+    .sort(compareSearchSnippetResults)
+
+  if (input.limit && input.limit > 0) {
+    return scored.slice(0, input.limit)
+  }
+  return scored
+}
+
+const compareSearchSnippetResults = (
+  a: SearchSnippetsUseCaseResult,
+  b: SearchSnippetsUseCaseResult
+): number => {
+  if (b.score !== a.score) {
+    return b.score - a.score
+  }
+
+  if (a.snippet.isFavorite !== b.snippet.isFavorite) {
+    return a.snippet.isFavorite ? -1 : 1
+  }
+
+  if (b.snippet.usageCount !== a.snippet.usageCount) {
+    return b.snippet.usageCount - a.snippet.usageCount
+  }
+
+  const aTime = a.snippet.updatedAt.getTime()
+  const bTime = b.snippet.updatedAt.getTime()
+  if (bTime !== aTime) {
+    return bTime - aTime
+  }
+
+  return a.snippet.title.localeCompare(b.snippet.title)
 }


### PR DESCRIPTION
## 概要
- 空クエリ時に表示するお気に入り+最近利用候補を返す `GetTopSnippetsForEmptyQueryUseCase` を実装し、`SearchSnippetsUseCase` へ委譲できるようにしました。
- 検索ユースケース側のロジックをリファクタリングし、スコアリング定数・空クエリ用ビルダ・ライブラリ/タグフィルタ処理を外部から再利用できるユーティリティとして切り出しました。
- `src/core/usecases/snippet/index.ts` から新ユースケースを再エクスポートし、依存注入を簡潔にしています。

## 影響範囲
- `GetTopSnippetsForEmptyQueryUseCase` を `SearchSnippetsUseCase` の `emptyQueryStrategy` として差し込むことで、空クエリ時の候補計算を独立させてテストしやすくなります。
- 既存の検索スコアリングはリファクタリングのみで挙動は変わりません。

## 動作確認
- `npm run build`

Closes #17