### PR TITLE
feat: フィルタUIと検索スコアリングテストを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,10 @@ type Snippet = {
 
 アプリ起動時に検索バーへフォーカスし、下部に「最近使った & お気に入り」を並べる。入力に応じて即時フィルタ、`Enter` でトップ候補をコピー、`↓ / ↑` で移動…といった操作を前提に、ユースケース層で「最上位に表示すべきスニペット」をきちんと決めておく。
 
+### 7.5 ライブラリ / タグ複合フィルタ
+
+UI 側では Personal / Team など複数ライブラリをトグルできるチップと、タグごとの複合フィルタを提供する。状態は `SearchSnippetsUseCase` にそのまま渡され、ライブラリ ID 配列・タグ配列で条件を掛け合わせる。All を選択した場合は全ライブラリが検索対象になり、タグはすべて一致したスニペットのみを結果に含める。フィルタ状態は `GetTopSnippetsForEmptyQueryUseCase` にも引き継がれるため、空クエリでもコンテキストに沿った候補だけが提示される。
+
 ---
 
 ## 8. 次のアクション
@@ -396,3 +400,13 @@ type Snippet = {
 - `src/core/domain/snippet/Snippet.ts` で拡張フィールドを定義する。
 - `src/core/domain/snippet/SnippetDataAccessAdapter.ts` と `src/core/usecases/SearchSnippets.ts` を TypeScript 実装し、`App.tsx` からロジックを切り出す。
 - Personal / Team スコープの UX を固めたうえで、必要に応じて Project など追加カテゴリを段階的に公開する。
+
+## 9. アーキテクチャ図
+
+Mermaid で各レイヤの依存関係をまとめた図を [docs/architecture-diagram.md](docs/architecture-diagram.md) に掲載している。React UI・ユースケース・ドメイン・データアクセス・Tauri コマンド・OS ストレージ間のフローを確認したい場合に参照すること。
+
+## 10. 開発コマンドとテスト
+
+- `npm run dev` : Vite 開発サーバーを起動し、フィルタ UI や検索体験を即座に確認する。
+- `npm run build` : TypeScript 型チェックと Vite の本番ビルドを走らせる。
+- `npm run test` : Vitest 実行。`SearchSnippetsUseCase` のスコアリングやフィルタリングをユニットテストで検証し、shortcut/タグ/ライブラリ条件の退行を防ぐ。

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,8 @@
         "@types/react-dom": "^19.1.6",
         "@vitejs/plugin-react": "^4.6.0",
         "typescript": "~5.8.3",
-        "vite": "^7.0.4"
+        "vite": "^7.0.4",
+        "vitest": "^4.0.9"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1112,6 +1113,13 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
+      "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tauri-apps/api": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.9.0.tgz",
@@ -1393,6 +1401,24 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1440,6 +1466,127 @@
       },
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.9.tgz",
+      "integrity": "sha512-C2vyXf5/Jfj1vl4DQYxjib3jzyuswMi/KHHVN2z+H4v16hdJ7jMZ0OGe3uOVIt6LyJsAofDdaJNIFEpQcrSTFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.0.9",
+        "@vitest/utils": "4.0.9",
+        "chai": "^6.2.0",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.9.tgz",
+      "integrity": "sha512-PUyaowQFHW+9FKb4dsvvBM4o025rWMlEDXdWRxIOilGaHREYTi5Q2Rt9VCgXgPy/hHZu1LeuXtrA/GdzOatP2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.0.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.9.tgz",
+      "integrity": "sha512-Hor0IBTwEi/uZqB7pvGepyElaM8J75pYjrrqbC8ZYMB9/4n5QA63KC15xhT+sqHpdGWfdnPo96E8lQUxs2YzSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.9.tgz",
+      "integrity": "sha512-aF77tsXdEvIJRkj9uJZnHtovsVIx22Ambft9HudC+XuG/on1NY/bf5dlDti1N35eJT+QZLb4RF/5dTIG18s98w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.0.9",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.9.tgz",
+      "integrity": "sha512-r1qR4oYstPbnOjg0Vgd3E8ADJbi4ditCzqr+Z9foUrRhIy778BleNyZMeAJ2EjV+r4ASAaDsdciC9ryMy8xMMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.9",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.9.tgz",
+      "integrity": "sha512-J9Ttsq0hDXmxmT8CUOWUr1cqqAj2FJRGTdyEjSR+NjoOGKEqkEWj+09yC0HhI8t1W6t4Ctqawl1onHgipJve1A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.9.tgz",
+      "integrity": "sha512-cEol6ygTzY4rUPvNZM19sDf7zGa35IYTm9wfzkHoT/f5jX10IOY7QleWSOh5T0e3I3WVozwK5Asom79qW8DiuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.9",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/baseline-browser-mapping": {
@@ -1508,6 +1655,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.1.tgz",
+      "integrity": "sha512-p4Z49OGG5W/WBCPSS/dH3jQ73kD6tiMmUM+bckNK6Jr5JHMG3k9bg/BvKR8lKmtVBKmOiuVaV2ws8s9oSbwysg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -1546,6 +1703,13 @@
       "integrity": "sha512-53uTpjtRgS7gjIxZ4qCgFdNO2q+wJt/Z8+xAvxbCqXPJrY6h7ighUkadQmNMXH96crtpa6gPFNP7BF4UBGDuaA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.25.12",
@@ -1597,6 +1761,26 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.2.tgz",
+      "integrity": "sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fdir": {
@@ -1685,6 +1869,16 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -1715,6 +1909,13 @@
       "version": "2.0.27",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
     },
@@ -1858,6 +2059,13 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -1867,6 +2075,34 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
@@ -1883,6 +2119,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
+      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/typescript": {
@@ -2004,6 +2250,101 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.9.tgz",
+      "integrity": "sha512-E0Ja2AX4th+CG33yAFRC+d1wFx2pzU5r6HtG6LiPSE04flaE0qB6YyjSw9ZcpJAtVPfsvZGtJlKWZpuW7EHRxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.0.9",
+        "@vitest/mocker": "4.0.9",
+        "@vitest/pretty-format": "4.0.9",
+        "@vitest/runner": "4.0.9",
+        "@vitest/snapshot": "4.0.9",
+        "@vitest/spy": "4.0.9",
+        "@vitest/utils": "4.0.9",
+        "debug": "^4.4.3",
+        "es-module-lexer": "^1.7.0",
+        "expect-type": "^1.2.2",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^3.10.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.0.9",
+        "@vitest/browser-preview": "4.0.9",
+        "@vitest/browser-webdriverio": "4.0.9",
+        "@vitest/ui": "4.0.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/yallist": {

--- a/package.json
+++ b/package.json
@@ -7,20 +7,22 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "tauri": "tauri"
+    "tauri": "tauri",
+    "test": "vitest run"
   },
   "dependencies": {
-    "react": "^19.1.0",
-    "react-dom": "^19.1.0",
     "@tauri-apps/api": "^2",
-    "@tauri-apps/plugin-opener": "^2"
+    "@tauri-apps/plugin-opener": "^2",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0"
   },
   "devDependencies": {
+    "@tauri-apps/cli": "^2",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "^4.6.0",
     "typescript": "~5.8.3",
     "vite": "^7.0.4",
-    "@tauri-apps/cli": "^2"
+    "vitest": "^4.0.9"
   }
 }

--- a/src/core/usecases/snippet/searchSnippetsUseCase.test.ts
+++ b/src/core/usecases/snippet/searchSnippetsUseCase.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest'
+
+import type { Snippet } from '../../domain/snippet'
+import { InMemorySnippetDataAccessAdapter } from '../../data-access/snippet'
+import { SearchSnippetsUseCase } from './searchSnippetsUseCase'
+
+const baseDate = new Date('2024-01-01T00:00:00Z')
+
+const createSnippet = (input: Partial<Snippet> & { id: string; title: string; body: string }): Snippet => ({
+  id: input.id,
+  title: input.title,
+  body: input.body,
+  tags: input.tags ?? [],
+  shortcut: input.shortcut ?? null,
+  description: input.description ?? null,
+  language: input.language ?? null,
+  isFavorite: input.isFavorite ?? false,
+  usageCount: input.usageCount ?? 0,
+  lastUsedAt: input.lastUsedAt ?? null,
+  libraryId: input.libraryId ?? 'personal',
+  createdAt: input.createdAt ?? baseDate,
+  updatedAt: input.updatedAt ?? baseDate,
+})
+
+const createUseCase = (snippets: Snippet[], overrides?: { now?: () => Date }) =>
+  new SearchSnippetsUseCase({
+    snippetGateway: new InMemorySnippetDataAccessAdapter(snippets),
+    ...overrides,
+  })
+
+describe('SearchSnippetsUseCase', () => {
+  it('prioritizes shortcut matches over other signals', async () => {
+    const useCase = createUseCase([
+      createSnippet({
+        id: 'shortcut-match',
+        title: 'Deploy command',
+        body: 'deploy with script',
+        shortcut: 'deploy',
+        usageCount: 5,
+      }),
+      createSnippet({
+        id: 'favorite-match',
+        title: 'Deploy favorite',
+        body: 'deploy favorite',
+        isFavorite: true,
+      }),
+      createSnippet({
+        id: 'title-match',
+        title: 'Deploy via CLI',
+        body: 'cli deploy',
+      }),
+    ])
+
+    const results = await useCase.execute({ query: 'deploy' })
+    expect(results.map(result => result.snippet.id)).toEqual([
+      'shortcut-match',
+      'favorite-match',
+      'title-match',
+    ])
+    expect(results[0].score).toBeGreaterThan(results[1].score)
+  })
+
+  it('filters by library ids when provided', async () => {
+    const useCase = createUseCase([
+      createSnippet({
+        id: 'personal-api',
+        title: 'API call personal',
+        body: 'api request',
+        libraryId: 'personal',
+      }),
+      createSnippet({
+        id: 'team-api',
+        title: 'API call team',
+        body: 'api request team',
+        libraryId: 'team',
+        tags: ['api', 'team'],
+      }),
+    ])
+
+    const results = await useCase.execute({ query: 'api', libraryIds: ['team'] })
+    expect(results).toHaveLength(1)
+    expect(results[0].snippet.id).toBe('team-api')
+  })
+
+  it('requires all selected tags to be present', async () => {
+    const useCase = createUseCase([
+      createSnippet({
+        id: 'redis-cache',
+        title: 'Redis cache priming',
+        body: 'cache warmup',
+        tags: ['redis', 'cache'],
+      }),
+      createSnippet({
+        id: 'redis-only',
+        title: 'Redis helpers',
+        body: 'redis script',
+        tags: ['redis'],
+      }),
+    ])
+
+    const results = await useCase.execute({ query: 'cache', tags: ['redis', 'cache'] })
+    expect(results).toHaveLength(1)
+    expect(results[0].snippet.id).toBe('redis-cache')
+  })
+
+  it('uses usageCount and recency bonuses to break ties', async () => {
+    const recent = new Date('2024-01-05T00:00:00Z')
+    const older = new Date('2024-01-02T00:00:00Z')
+    const useCase = createUseCase(
+      [
+        createSnippet({
+          id: 'high-usage',
+          title: 'Logger setup',
+          body: 'logger info',
+          tags: ['log'],
+          usageCount: 20,
+          lastUsedAt: older,
+        }),
+        createSnippet({
+          id: 'recent',
+          title: 'Logger advanced',
+          body: 'logger debug',
+          tags: ['log'],
+          usageCount: 5,
+          lastUsedAt: recent,
+        }),
+      ],
+      { now: () => new Date('2024-01-06T00:00:00Z') }
+    )
+
+    const results = await useCase.execute({ query: 'log' })
+    expect(results.map(result => result.snippet.id)).toEqual(['high-usage', 'recent'])
+    expect(results[0].score).toBeGreaterThan(results[1].score)
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
+    "types": ["vitest/globals"],
 
     /* Linting */
     "strict": true,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+    include: ['src/**/*.test.ts'],
+  },
+})


### PR DESCRIPTION
## 概要
- App.tsx にライブラリ／タグの複合フィルタ UI を追加し、`SearchSnippetsUseCase` と `GetTopSnippetsForEmptyQueryUseCase` を用いた検索結果に反映できるようにしました。
- `SearchSnippetsUseCase` のスコアリングを Vitest で検証するユニットテストを整備し、shortcut・ライブラリ・タグ・usageCount/lastUsedAt の主要ルールをカバーしました。
- README にフィルタ方針と `npm run test` コマンドを追記し、ビルド／テスト手順を明記しました。

## 影響範囲
- フロント UI: ライブラリとタグのトグルチップが追加され、空クエリ時もフィルタが尊重されます。
- 検索ユースケース: テスト追加のみで挙動変更はありません。

## テスト
- `npm run build`
- `npm run test`

Closes #31
Closes #41