### PR TITLE
UI: 検索コンポーネント分割と通知・ショートカット対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,3 +410,10 @@ Mermaid で各レイヤの依存関係をまとめた図を [docs/architecture-d
 - `npm run dev` : Vite 開発サーバーを起動し、フィルタ UI や検索体験を即座に確認する。
 - `npm run build` : TypeScript 型チェックと Vite の本番ビルドを走らせる。
 - `npm run test` : Vitest 実行。`SearchSnippetsUseCase` のスコアリングやフィルタリングをユニットテストで検証し、shortcut/タグ/ライブラリ条件の退行を防ぐ。
+
+## 11. UI 操作ヒントとショートカット
+
+- React 側の UI は検索バー・フィルタ・スニペットリストを `src/components/` 配下に分割し、メンテナンスしやすい構造にしている。`SearchInput` が初期フォーカスとフォーカス制御を担い、`SnippetList` は検索結果/空クエリ用候補を同じ描画ロジックで切り替える。
+- 空クエリ時は `GetTopSnippetsForEmptyQueryUseCase` の結果（お気に入り + 最近使用）を優先的に表示し、「候補が無い」状態を明示するメッセージを出す。
+- ライブラリ切替は `⌘1`（All）/`⌘2`（Personal）/`⌘3`（Team）…… のショートカットに対応し、ショートカット操作でも UI のトグルが同期する。Windows/Linux では `Ctrl` キーで同じ操作が可能。
+- コピー失敗などの異常はアラートではなく通知トーストに集約し、複数イベントが続いてもスタックとして確認できる。通知は数秒で自動的に消える。

--- a/src/App.css
+++ b/src/App.css
@@ -1,116 +1,253 @@
-.logo.vite:hover {
-  filter: drop-shadow(0 0 2em #747bff);
-}
-
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafb);
-}
 :root {
-  font-family: Inter, Avenir, Helvetica, Arial, sans-serif;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
   font-size: 16px;
   line-height: 24px;
   font-weight: 400;
-
-  color: #0f0f0f;
-  background-color: #f6f6f6;
-
+  color: #e5e7eb;
+  background-color: #030712;
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   -webkit-text-size-adjust: 100%;
+
+  --surface: rgba(15, 23, 42, 0.92);
+  --surface-border: rgba(148, 163, 184, 0.35);
+  --surface-highlight: rgba(59, 130, 246, 0.25);
+  --surface-success: rgba(22, 163, 74, 0.6);
+  --primary: #60a5fa;
+  --primary-muted: #94a3b8;
+  --chip-bg: rgba(2, 6, 23, 0.8);
+  --chip-border: rgba(148, 163, 184, 0.3);
+  --tag-bg: rgba(31, 41, 55, 0.8);
+  --toast-bg: rgba(15, 23, 42, 0.95);
+  --toast-border: rgba(148, 163, 184, 0.4);
 }
 
-.container {
+body {
   margin: 0;
-  padding-top: 10vh;
+  min-height: 100vh;
+  background: radial-gradient(circle at top, #1e293b, #020617);
+  color: #e5e7eb;
+}
+
+.app-shell {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+}
+
+.command-surface {
+  width: 680px;
+  max-width: 95vw;
   display: flex;
   flex-direction: column;
-  justify-content: center;
-  text-align: center;
+  gap: 16px;
+  padding: 18px 22px 16px;
+  border-radius: 20px;
+  border: 1px solid var(--surface-border);
+  background: var(--surface);
+  box-shadow: 0 32px 80px rgba(0, 0, 0, 0.65);
+  backdrop-filter: blur(10px);
 }
 
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: 0.75s;
-}
-
-.logo.tauri:hover {
-  filter: drop-shadow(0 0 2em #24c8db);
-}
-
-.row {
+.command-header {
   display: flex;
-  justify-content: center;
+  justify-content: space-between;
+  align-items: center;
 }
 
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
+.command-header__title {
+  font-size: 18px;
+  letter-spacing: 0.04em;
+  font-weight: 600;
 }
 
-a:hover {
-  color: #535bf2;
+.command-header__caption {
+  font-size: 11px;
+  color: #94a3b8;
 }
 
-h1 {
-  text-align: center;
+.shortcut-badge {
+  font-size: 11px;
+  border: 1px solid var(--surface-border);
+  border-radius: 999px;
+  padding: 4px 8px;
+  opacity: 0.8;
 }
 
-input,
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  color: #0f0f0f;
-  background-color: #ffffff;
-  transition: border-color 0.25s;
-  box-shadow: 0 2px 2px rgba(0, 0, 0, 0.2);
+.search-bar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 12px;
+  border-radius: 14px;
+  border: 1px solid rgba(55, 65, 81, 0.9);
+  background: rgba(2, 6, 23, 0.9);
 }
 
-button {
-  cursor: pointer;
-}
-
-button:hover {
-  border-color: #396cd8;
-}
-button:active {
-  border-color: #396cd8;
-  background-color: #e8e8e8;
-}
-
-input,
-button {
+.search-bar__input {
+  flex: 1;
+  background: transparent;
+  border: none;
   outline: none;
+  color: inherit;
+  font-size: 14px;
 }
 
-#greet-input {
-  margin-right: 5px;
+.filters {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    color: #f6f6f6;
-    background-color: #2f2f2f;
-  }
+.filter-group {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
 
-  a:hover {
-    color: #24c8db;
-  }
+.filter-group__label {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--primary-muted);
+}
 
-  input,
-  button {
-    color: #ffffff;
-    background-color: #0f0f0f98;
-  }
-  button:active {
-    background-color: #0f0f0f69;
-  }
+.filter-chip {
+  font-size: 11px;
+  border-radius: 999px;
+  border: 1px solid var(--chip-border);
+  background: transparent;
+  color: var(--primary-muted);
+  padding: 2px 12px;
+  cursor: pointer;
+  transition: background 140ms ease, border-color 140ms ease;
+}
+
+.filter-chip.is-active {
+  border-color: rgba(59, 130, 246, 0.9);
+  background: rgba(37, 99, 235, 0.22);
+  color: #e2e8f0;
+}
+
+.filter-chip:focus-visible {
+  outline: 2px solid rgba(147, 197, 253, 0.4);
+  outline-offset: 1px;
+}
+
+.snippet-panel {
+  max-height: 320px;
+  overflow: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.snippet-panel__note {
+  font-size: 11px;
+  color: var(--primary-muted);
+  margin-bottom: -4px;
+}
+
+.snippet-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.snippet-item {
+  padding: 10px 10px;
+  border-radius: 12px;
+  border: 1px solid transparent;
+  cursor: pointer;
+  background: transparent;
+  transition: background 120ms ease, border-color 120ms ease;
+}
+
+.snippet-item.is-selected {
+  background: var(--surface-highlight);
+  border-color: rgba(59, 130, 246, 0.3);
+}
+
+.snippet-item.is-copied {
+  background: var(--surface-success);
+  border-color: rgba(34, 197, 94, 0.45);
+}
+
+.snippet-item__title {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.snippet-item__shortcut {
+  font-size: 10px;
+  padding: 1px 8px;
+  border-radius: 999px;
+  border: 1px solid var(--chip-border);
+  color: #cbd5f5;
+}
+
+.snippet-item__tags {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  margin-top: 4px;
+}
+
+.snippet-item__tag {
+  font-size: 10px;
+  padding: 2px 6px;
+  border-radius: 999px;
+  background: var(--tag-bg);
+  color: var(--primary-muted);
+}
+
+.snippet-item__body {
+  font-size: 11px;
+  color: var(--primary-muted);
+  margin-top: 6px;
+}
+
+.empty-state {
+  font-size: 12px;
+  color: #94a3b8;
+  padding: 12px 4px;
+}
+
+.toast-stack {
+  position: fixed;
+  bottom: 32px;
+  right: 32px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  z-index: 999;
+}
+
+.toast {
+  min-width: 220px;
+  padding: 10px 14px;
+  border-radius: 12px;
+  border: 1px solid var(--toast-border);
+  background: var(--toast-bg);
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.45);
+  font-size: 12px;
+}
+
+.toast--error {
+  border-color: rgba(248, 113, 113, 0.5);
+  color: #fecdd3;
+}
+
+.toast--success {
+  border-color: rgba(134, 239, 172, 0.5);
+  color: #bbf7d0;
 }

--- a/src/components/FilterChip.tsx
+++ b/src/components/FilterChip.tsx
@@ -1,0 +1,19 @@
+import type { ButtonHTMLAttributes, PropsWithChildren } from 'react'
+
+type FilterChipProps = PropsWithChildren<
+  ButtonHTMLAttributes<HTMLButtonElement> & {
+    active?: boolean
+  }
+>
+
+export function FilterChip({ active = false, children, className = '', ...rest }: FilterChipProps) {
+  const composedClassName = ['filter-chip', active ? 'is-active' : '', className]
+    .filter(Boolean)
+    .join(' ')
+
+  return (
+    <button type='button' className={composedClassName} {...rest}>
+      {children}
+    </button>
+  )
+}

--- a/src/components/FilterGroup.tsx
+++ b/src/components/FilterGroup.tsx
@@ -1,0 +1,14 @@
+import type { PropsWithChildren } from 'react'
+
+type FilterGroupProps = PropsWithChildren<{
+  label: string
+}>
+
+export function FilterGroup({ label, children }: FilterGroupProps) {
+  return (
+    <div className='filter-group'>
+      <span className='filter-group__label'>{label}</span>
+      {children}
+    </div>
+  )
+}

--- a/src/components/NotificationCenter.tsx
+++ b/src/components/NotificationCenter.tsx
@@ -1,0 +1,25 @@
+export type Notification = {
+  id: string
+  type: 'success' | 'error'
+  message: string
+}
+
+type NotificationCenterProps = {
+  notifications: Notification[]
+}
+
+export function NotificationCenter({ notifications }: NotificationCenterProps) {
+  if (notifications.length === 0) {
+    return null
+  }
+
+  return (
+    <div className='toast-stack' role='status' aria-live='polite'>
+      {notifications.map(notification => (
+        <div key={notification.id} className={`toast toast--${notification.type}`}>
+          {notification.message}
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/src/components/SearchInput.tsx
+++ b/src/components/SearchInput.tsx
@@ -1,0 +1,43 @@
+import { forwardRef, useEffect, useImperativeHandle, useRef } from 'react'
+
+type SearchInputProps = {
+  value: string
+  placeholder?: string
+  onChange: (value: string) => void
+}
+
+export type SearchInputHandle = {
+  focus: () => void
+}
+
+export const SearchInput = forwardRef<SearchInputHandle, SearchInputProps>(
+  ({ value, placeholder = 'Search snippets…', onChange }, ref) => {
+    const inputRef = useRef<HTMLInputElement | null>(null)
+
+    useImperativeHandle(ref, () => ({
+      focus: () => inputRef.current?.focus(),
+    }))
+
+    useEffect(() => {
+      inputRef.current?.focus()
+    }, [])
+
+    return (
+      <div className='search-bar'>
+        <input
+          ref={inputRef}
+          autoComplete='off'
+          spellCheck={false}
+          className='search-bar__input'
+          placeholder={placeholder}
+          type='text'
+          value={value}
+          onChange={event => onChange(event.target.value)}
+          aria-label='スニペット検索入力'
+        />
+      </div>
+    )
+  }
+)
+
+SearchInput.displayName = 'SearchInput'

--- a/src/components/SnippetList.tsx
+++ b/src/components/SnippetList.tsx
@@ -1,0 +1,77 @@
+import type { MouseEvent } from 'react'
+
+import type { Snippet } from '../core/domain/snippet'
+
+type SnippetListProps = {
+  snippets: Snippet[]
+  selectedSnippetId: string | null
+  copiedSnippetId: string | null
+  mode: 'search' | 'suggestion'
+  emptyMessage?: string
+  onSelect: (snippet: Snippet) => void
+  onHover: (index: number) => void
+}
+
+const truncateBody = (body: string): string => {
+  const normalized = body.replace(/\s+/g, ' ').trim()
+  return normalized.length > 80 ? `${normalized.slice(0, 80)}…` : normalized
+}
+
+export function SnippetList({
+  snippets,
+  selectedSnippetId,
+  copiedSnippetId,
+  onSelect,
+  onHover,
+  mode,
+  emptyMessage = '検索結果がありません',
+}: SnippetListProps) {
+  if (snippets.length === 0) {
+    return <div className='empty-state'>{emptyMessage}</div>
+  }
+
+  return (
+    <div className='snippet-list' aria-live='polite'>
+      {mode === 'suggestion' ? (
+        <div className='snippet-panel__note'>お気に入りと最近使用のスニペットを表示しています</div>
+      ) : null}
+      {snippets.map((snippet, index) => {
+        const isSelected = snippet.id === selectedSnippetId
+        const isCopied = snippet.id === copiedSnippetId
+        const className = ['snippet-item', isSelected ? 'is-selected' : '', isCopied ? 'is-copied' : '']
+          .filter(Boolean)
+          .join(' ')
+
+        const handleClick = (event: MouseEvent<HTMLDivElement>) => {
+          event.preventDefault()
+          onSelect(snippet)
+        }
+
+        return (
+          <div
+            key={snippet.id}
+            role='button'
+            tabIndex={0}
+            aria-pressed={isSelected}
+            className={className}
+            onMouseEnter={() => onHover(index)}
+            onClick={handleClick}
+          >
+            <div className='snippet-item__title'>
+              <span>{snippet.title}</span>
+              {snippet.shortcut ? <span className='snippet-item__shortcut'>{snippet.shortcut}</span> : null}
+            </div>
+            <div className='snippet-item__tags'>
+              {snippet.tags.map(tag => (
+                <span key={tag} className='snippet-item__tag'>
+                  {tag}
+                </span>
+              ))}
+            </div>
+            <div className='snippet-item__body'>{truncateBody(snippet.body)}</div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,0 +1,5 @@
+export * from './FilterChip'
+export * from './FilterGroup'
+export * from './NotificationCenter'
+export * from './SearchInput'
+export * from './SnippetList'


### PR DESCRIPTION
## 変更内容
- 検索バー・フィルタ・スニペット一覧を `src/components/` に分割し、App.tsx はユースケース呼び出し中心のシンプルな構成に整理
- ライブラリ/タグフィルタをチップ化し、空クエリ専用サジェスト表示とコピー失敗用トースト通知を追加
- ⌘1/⌘2/⌘3 ショートカットによるライブラリ切り替えと README の UI 操作ドキュメントを整備

## 動作確認
- `npm run build`
- `npm run test`

Closes #24
Closes #25
Closes #26
Closes #28
Closes #29
Closes #30
Closes #31