### PR TITLE
feat: CreateSnippetUseCase の実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,8 @@ type UserPreferences = {
 3. `SnippetDataAccessAdapter.save(snippet)` を呼び出し、永続化。
 4. 成功したスニペットを返す。
 
+実装は `src/core/usecases/snippet/createSnippetUseCase.ts` で行い、DTO から `constructSnippet` を呼び出してドメインルール検証と保存を直列化している。
+
 ---
 
 ### UC-03: スニペットを編集する

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -22,7 +22,7 @@
 - [ ] [P0] `SearchSnippetsUseCase` を実装し、クエリ・ライブラリ・タグ条件を受け、デザイン記載のスコアリングルールを網羅する。
 - [ ] [P1] `GetTopSnippetsForEmptyQueryUseCase` を作成し、空クエリ時にお気に入り＋最近利用スニペットを返す処理を切り出す。
 - [ ] [P0] `CopySnippetUseCase` を実装し、Snippet 取得→Tauri クリップボードコマンド呼び出し→`usageCount`/`lastUsedAt` 更新→保存までを直列化する。
-- [ ] [P0] `CreateSnippetUseCase` を実装し、入力 DTO→`constructSnippet`→保存→結果返却のフローを整備する。
+- [x] [P0] `CreateSnippetUseCase` を実装し、入力 DTO→`constructSnippet`→保存→結果返却のフローを整備する。
 - [ ] [P0] `UpdateSnippetUseCase` で差分マージと `updatedAt` 更新、ReadOnly ライブラリチェックを行う（`applySnippetUpdate` を利用）。
 - [ ] [P0] `DeleteSnippetUseCase` で削除と UI 通知（例: 成功イベント）を提供する。
 - [ ] [P1] `GetAllLibrariesUseCase` を作成して Personal/Team の表示用データ（name/category/isReadOnly）を返す。

--- a/src/core/usecases/snippet/createSnippetUseCase.test.ts
+++ b/src/core/usecases/snippet/createSnippetUseCase.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  SnippetValidationError,
+  type LibraryId,
+  type Snippet,
+  type SnippetDataAccessAdapter,
+  type SnippetId,
+} from '../../domain/snippet'
+import { CreateSnippetUseCase } from './createSnippetUseCase'
+
+class SpySnippetGateway implements SnippetDataAccessAdapter {
+  readonly savedSnippets: Snippet[] = []
+
+  async getAll(): Promise<Snippet[]> {
+    return []
+  }
+
+  async getById(): Promise<Snippet | null> {
+    return null
+  }
+
+  async save(snippet: Snippet): Promise<void> {
+    this.savedSnippets.push(snippet)
+  }
+
+  async delete(): Promise<void> {
+    // noop
+  }
+}
+
+const fixedNow = new Date('2024-02-01T12:00:00Z')
+
+const createUseCase = (options?: {
+  gateway?: SpySnippetGateway
+  defaultLibraryId?: LibraryId
+  generateId?: () => SnippetId
+  now?: () => Date
+}) => {
+  const gateway = options?.gateway ?? new SpySnippetGateway()
+  const generateId = options?.generateId ?? vi.fn<() => SnippetId>(() => 'snippet-id')
+
+  return {
+    gateway,
+    useCase: new CreateSnippetUseCase({
+      snippetGateway: gateway,
+      generateId,
+      defaultLibraryId: options?.defaultLibraryId,
+      now: options?.now ?? (() => fixedNow),
+    }),
+  }
+}
+
+describe('CreateSnippetUseCase', () => {
+  it('constructs a snippet and persists it via the gateway', async () => {
+    const { useCase, gateway } = createUseCase()
+
+    const result = await useCase.execute({
+      title: 'New snippet',
+      body: 'console.log("hi")',
+      tags: ['ts'],
+      shortcut: 'ns',
+      description: 'Sample',
+      language: 'typescript',
+      libraryId: 'personal',
+      isFavorite: true,
+    })
+
+    expect(result.id).toBe('snippet-id')
+    expect(result.createdAt).toEqual(fixedNow)
+    expect(result.updatedAt).toEqual(fixedNow)
+    expect(result.usageCount).toBe(0)
+    expect(result.lastUsedAt).toBeNull()
+    expect(gateway.savedSnippets).toHaveLength(1)
+    expect(gateway.savedSnippets[0]).toEqual(result)
+  })
+
+  it('applies default library when not provided', async () => {
+    const { useCase } = createUseCase({ defaultLibraryId: 'team' })
+
+    const result = await useCase.execute({
+      title: 'Team note',
+      body: 'body',
+    })
+
+    expect(result.libraryId).toBe('team')
+  })
+
+  it('throws when neither libraryId nor defaultLibraryId is provided', async () => {
+    const { useCase, gateway } = createUseCase()
+
+    await expect(
+      useCase.execute({
+        title: 'Missing library',
+        body: 'body',
+      }),
+    ).rejects.toThrowError('libraryId is required')
+
+    expect(gateway.savedSnippets).toHaveLength(0)
+  })
+
+  it('propagates validation errors and does not persist invalid snippets', async () => {
+    const { useCase, gateway } = createUseCase({ defaultLibraryId: 'personal' })
+
+    await expect(
+      useCase.execute({
+        title: '',
+        body: '',
+      }),
+    ).rejects.toBeInstanceOf(SnippetValidationError)
+
+    expect(gateway.savedSnippets).toHaveLength(0)
+  })
+})

--- a/src/core/usecases/snippet/createSnippetUseCase.ts
+++ b/src/core/usecases/snippet/createSnippetUseCase.ts
@@ -1,0 +1,72 @@
+import {
+  constructSnippet,
+  type LibraryId,
+  type Snippet,
+  type SnippetDataAccessAdapter,
+  type SnippetId,
+  type TagName,
+} from '../../domain/snippet'
+
+export type CreateSnippetUseCaseInput = {
+  title: string
+  body: string
+  shortcut?: string | null
+  description?: string | null
+  tags?: TagName[]
+  language?: string | null
+  libraryId?: LibraryId
+  isFavorite?: boolean
+}
+
+export type CreateSnippetUseCaseDependencies = {
+  snippetGateway: SnippetDataAccessAdapter
+  generateId: () => SnippetId
+  now?: () => Date
+  defaultLibraryId?: LibraryId
+}
+
+/**
+ * 新規スニペットを作成して保存するユースケース。
+ * constructSnippet を通じてドメインルールを検証し、成功したら永続化する。
+ */
+export class CreateSnippetUseCase {
+  private readonly snippetGateway: SnippetDataAccessAdapter
+  private readonly generateId: () => SnippetId
+  private readonly now: () => Date
+  private readonly defaultLibraryId?: LibraryId
+
+  constructor(deps: CreateSnippetUseCaseDependencies) {
+    this.snippetGateway = deps.snippetGateway
+    this.generateId = deps.generateId
+    this.now = deps.now ?? (() => new Date())
+    this.defaultLibraryId = deps.defaultLibraryId
+  }
+
+  async execute(input: CreateSnippetUseCaseInput): Promise<Snippet> {
+    const timestamp = this.now()
+    const libraryId = input.libraryId ?? this.defaultLibraryId
+
+    if (!libraryId) {
+      throw new Error('libraryId is required when no defaultLibraryId is configured')
+    }
+
+    const snippet = constructSnippet({
+      id: this.generateId(),
+      title: input.title,
+      body: input.body,
+      shortcut: input.shortcut ?? null,
+      description: input.description ?? null,
+      tags: input.tags ?? [],
+      language: input.language ?? null,
+      isFavorite: input.isFavorite ?? false,
+      usageCount: 0,
+      lastUsedAt: null,
+      libraryId,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    })
+
+    await this.snippetGateway.save(snippet)
+    return snippet
+  }
+}

--- a/src/core/usecases/snippet/index.ts
+++ b/src/core/usecases/snippet/index.ts
@@ -1,3 +1,4 @@
 export * from './copySnippetUseCase'
+export * from './createSnippetUseCase'
 export * from './searchSnippetsUseCase'
 export * from './getTopSnippetsForEmptyQueryUseCase'


### PR DESCRIPTION
## 概要
- `CreateSnippetUseCase` を追加し、入力 DTO から `constructSnippet` を経由して保存するフローを実装
- 新規ユースケースの単体テストを Vitest で追加
- README と docs/tasks.md を更新して実装状況を反映

Closes #19

## 動作確認
- `npx vitest run`
- `npm run build`
