### PR TITLE
fix: CopySnippetUseCase のエラーハンドリングを実装

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -21,7 +21,7 @@
 ## ユースケース
 - [ ] [P0] `SearchSnippetsUseCase` を実装し、クエリ・ライブラリ・タグ条件を受け、デザイン記載のスコアリングルールを網羅する。
 - [ ] [P1] `GetTopSnippetsForEmptyQueryUseCase` を作成し、空クエリ時にお気に入り＋最近利用スニペットを返す処理を切り出す。
-- [ ] [P0] `CopySnippetUseCase` を実装し、Snippet 取得→Tauri クリップボードコマンド呼び出し→`usageCount`/`lastUsedAt` 更新→保存までを直列化する。
+- [x] [P0] `CopySnippetUseCase` を実装し、Snippet 取得→Tauri クリップボードコマンド呼び出し→`usageCount`/`lastUsedAt` 更新→保存までを直列化する。
 - [x] [P0] `CreateSnippetUseCase` を実装し、入力 DTO→`constructSnippet`→保存→結果返却のフローを整備する。
 - [ ] [P0] `UpdateSnippetUseCase` で差分マージと `updatedAt` 更新、ReadOnly ライブラリチェックを行う（`applySnippetUpdate` を利用）。
 - [ ] [P0] `DeleteSnippetUseCase` で削除と UI 通知（例: 成功イベント）を提供する。
@@ -53,7 +53,7 @@
 ## テスト
 - [ ] [P0] Vitest + React Testing Library を導入し、`App.test.tsx` で基本 UI 挙動（検索・コピー・エラー表示）を確認する。
 - [ ] [P0] `SearchSnippetsUseCase` のスコアリングをユニットテストで網羅し、shortcut 完全一致やタグ一致など主要パターンを検証する。
-- [ ] [P1] `CopySnippetUseCase` の `usageCount`/`lastUsedAt` 更新ロジックとクリップボード失敗ハンドリングをテストする。
+- [x] [P1] `CopySnippetUseCase` の `usageCount`/`lastUsedAt` 更新ロジックとクリップボード失敗ハンドリングをテストする。
 - [ ] [P1] ReadOnly ライブラリへの書き込み禁止が `Create/Update/Delete` ユースケースで正しく動作するかテストする。
 - [ ] [P2] `GetTopSnippetsForEmptyQueryUseCase` がお気に入り＋最近使用の優先順を保証するテストを追加する。
 - [ ] [P1] `src-tauri/src/lib.rs` などに単体テストを書き、ファイルアクセスコマンドや JSON パーサの基本ケースを検証する。

--- a/src/core/domain/snippet/errors/index.ts
+++ b/src/core/domain/snippet/errors/index.ts
@@ -38,3 +38,10 @@ export class SnippetNotFoundError extends Error {
     this.name = 'SnippetNotFoundError'
   }
 }
+
+export class ClipboardCopyError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'ClipboardCopyError'
+  }
+}

--- a/src/core/usecases/snippet/copySnippetUseCase.test.ts
+++ b/src/core/usecases/snippet/copySnippetUseCase.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type {
+  ClipboardGateway,
+  Snippet,
+  SnippetDataAccessAdapter,
+  SnippetId,
+} from '../../domain/snippet'
+import {
+  ClipboardCopyError,
+  SnippetNotFoundError,
+} from '../../domain/snippet'
+import { CopySnippetUseCase } from './copySnippetUseCase'
+
+const createSnippet = (overrides: Partial<Snippet> & { id: SnippetId }): Snippet => ({
+  id: overrides.id,
+  title: overrides.title ?? 'title',
+  body: overrides.body ?? 'body',
+  tags: overrides.tags ?? [],
+  shortcut: overrides.shortcut ?? null,
+  description: overrides.description ?? null,
+  language: overrides.language ?? null,
+  isFavorite: overrides.isFavorite ?? false,
+  usageCount: overrides.usageCount ?? 0,
+  lastUsedAt: overrides.lastUsedAt ?? null,
+  libraryId: overrides.libraryId ?? 'personal',
+  createdAt: overrides.createdAt ?? new Date('2024-01-01T00:00:00Z'),
+  updatedAt: overrides.updatedAt ?? new Date('2024-01-01T00:00:00Z'),
+})
+
+class SpySnippetGateway implements SnippetDataAccessAdapter {
+  private readonly records = new Map<SnippetId, Snippet>()
+
+  constructor(initialSnippets: Snippet[]) {
+    initialSnippets.forEach(snippet => this.records.set(snippet.id, { ...snippet }))
+  }
+
+  async getAll(): Promise<Snippet[]> {
+    return Array.from(this.records.values()).map(snippet => ({ ...snippet }))
+  }
+
+  async getById(id: SnippetId): Promise<Snippet | null> {
+    const snippet = this.records.get(id)
+    return snippet ? { ...snippet } : null
+  }
+
+  async save(snippet: Snippet): Promise<void> {
+    this.records.set(snippet.id, { ...snippet })
+  }
+
+  async delete(id: SnippetId): Promise<void> {
+    this.records.delete(id)
+  }
+}
+
+class StubClipboardGateway implements ClipboardGateway {
+  readonly copyText = vi.fn((_text: string) => Promise.resolve())
+}
+
+describe('CopySnippetUseCase', () => {
+  it('increments usage statistics and persists the snippet', async () => {
+    const snippet = createSnippet({ id: 'typescript', body: 'console.log("hi")' })
+    const gateway = new SpySnippetGateway([snippet])
+    const clipboard = new StubClipboardGateway()
+    const now = new Date('2024-02-01T00:00:00Z')
+
+    const useCase = new CopySnippetUseCase({
+      snippetGateway: gateway,
+      clipboardGateway: clipboard,
+      now: () => now,
+    })
+
+    const updated = await useCase.execute({ snippetId: snippet.id })
+
+    expect(clipboard.copyText).toHaveBeenCalledWith('console.log("hi")')
+    expect(updated.usageCount).toBe(1)
+    expect(updated.lastUsedAt).toEqual(now)
+    expect(updated.updatedAt).toEqual(now)
+
+    const persisted = await gateway.getById(snippet.id)
+    expect(persisted?.usageCount).toBe(1)
+  })
+
+  it('throws SnippetNotFoundError when id is missing', async () => {
+    const gateway = new SpySnippetGateway([])
+    const clipboard = new StubClipboardGateway()
+
+    const useCase = new CopySnippetUseCase({
+      snippetGateway: gateway,
+      clipboardGateway: clipboard,
+    })
+
+    await expect(useCase.execute({ snippetId: 'missing' })).rejects.toBeInstanceOf(SnippetNotFoundError)
+  })
+
+  it('wraps clipboard failures into ClipboardCopyError', async () => {
+    const snippet = createSnippet({ id: 'rust', body: 'println!("hi");' })
+    const gateway = new SpySnippetGateway([snippet])
+    const clipboard = new StubClipboardGateway()
+    clipboard.copyText.mockRejectedValueOnce(new Error('permission denied'))
+
+    const useCase = new CopySnippetUseCase({
+      snippetGateway: gateway,
+      clipboardGateway: clipboard,
+    })
+
+    await expect(useCase.execute({ snippetId: 'rust' })).rejects.toBeInstanceOf(ClipboardCopyError)
+    const persisted = await gateway.getById('rust')
+    expect(persisted?.usageCount).toBe(0)
+  })
+})

--- a/src/core/usecases/snippet/copySnippetUseCase.ts
+++ b/src/core/usecases/snippet/copySnippetUseCase.ts
@@ -4,7 +4,10 @@ import type {
   SnippetDataAccessAdapter,
   SnippetId,
 } from '../../domain/snippet'
-import { SnippetNotFoundError } from '../../domain/snippet'
+import {
+  ClipboardCopyError,
+  SnippetNotFoundError,
+} from '../../domain/snippet'
 
 export type CopySnippetUseCaseInput = {
   snippetId: SnippetId
@@ -37,7 +40,12 @@ export class CopySnippetUseCase {
       throw new SnippetNotFoundError(input.snippetId)
     }
 
-    await this.clipboardGateway.copyText(snippet.body)
+    try {
+      await this.clipboardGateway.copyText(snippet.body)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'clipboard copy failed'
+      throw new ClipboardCopyError(message)
+    }
 
     const timestamp = this.now()
     const updatedSnippet: Snippet = {


### PR DESCRIPTION
## 概要
- `CopySnippetUseCase` でクリップボードの失敗を `ClipboardCopyError` に変換し、UI からも失敗理由を把握しやすくしました。
- ユースケースの単体テストを追加し、`usageCount`/`lastUsedAt` 更新と例外経路をカバーしました。
- `docs/tasks.md` の該当項目を完了済みに更新しました。

Closes #18

## 動作確認
- `npm run test`
- `npm run build`
