### PR TITLE
feat: redesign search view as command palette

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ CodeSpark はローカルに保存したスニペットを検索・コピーで�
 ## 2. 現在の実装状況
 | 領域 | 実装内容 |
 | --- | --- |
-| UI | 検索バー、ライブラリ/タグフィルタ、スニペット一覧、通知、作成フォーム、編集フォームを分割配置。`Enter` / `↑↓` / `⌘J,K` で候補操作、`⌘Enter`（Ctrl+Enter）でエディタにフォーカス。空クエリではお気に入り + 最近利用を `GetTopSnippetsForEmptyQueryUseCase` 経由で提示。 |
+| UI | 検索バーと結果リストのみを基本表示とし、`Enter` / `↑↓` / `⌘J,K` で候補操作、`⌘Enter`（Ctrl+Enter）で編集ビューへ遷移するコマンドパレット式 UX。`/create` などでモード切替。 |
 | ドメイン | `src/core/domain/snippet` に Snippet / Library / Preferences などの型、`constructSnippet`・`applySnippetUpdate`、バリデーションエラー、ReadOnly 例外を集約。 |
 | ユースケース | 検索・空クエリサジェスト・コピー・作成・更新・削除を個別クラスで実装し、`App.tsx` から依存注入。使用履歴とライブラリ保護を含むテストを `src/core/usecases/snippet/*.test.ts` に用意。 |
 | データアクセス | Tauri 実行時は `FileSnippetDataAccessAdapter` を介して `codespark/snippets.json` へ永続化する。ブラウザ開発や Vitest では `InMemorySnippetDataAccessAdapter` を自動利用。`VITE_USE_IN_MEMORY_SNIPPETS=true` で明示的に切り替え可能。 |

--- a/src/App.css
+++ b/src/App.css
@@ -53,31 +53,6 @@ body {
   backdrop-filter: blur(10px);
 }
 
-.command-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
-
-.command-header__title {
-  font-size: 18px;
-  letter-spacing: 0.04em;
-  font-weight: 600;
-}
-
-.command-header__caption {
-  font-size: 11px;
-  color: #94a3b8;
-}
-
-.shortcut-badge {
-  font-size: 11px;
-  border: 1px solid var(--surface-border);
-  border-radius: 999px;
-  padding: 4px 8px;
-  opacity: 0.8;
-}
-
 .search-bar {
   display: flex;
   align-items: center;
@@ -97,54 +72,51 @@ body {
   font-size: 14px;
 }
 
-.filters {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-
-.filter-group {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  flex-wrap: wrap;
-}
-
-.filter-group__label {
-  font-size: 10px;
-  text-transform: uppercase;
-  letter-spacing: 0.12em;
-  color: var(--primary-muted);
-}
-
-.filter-chip {
-  font-size: 11px;
-  border-radius: 999px;
-  border: 1px solid var(--chip-border);
-  background: transparent;
-  color: var(--primary-muted);
-  padding: 2px 12px;
-  cursor: pointer;
-  transition: background 140ms ease, border-color 140ms ease;
-}
-
-.filter-chip.is-active {
-  border-color: rgba(59, 130, 246, 0.9);
-  background: rgba(37, 99, 235, 0.22);
-  color: #e2e8f0;
-}
-
-.filter-chip:focus-visible {
-  outline: 2px solid rgba(147, 197, 253, 0.4);
-  outline-offset: 1px;
-}
-
 .snippet-panel {
   max-height: 320px;
   overflow: auto;
   display: flex;
   flex-direction: column;
   gap: 8px;
+}
+
+.command-surface--panel {
+  width: 720px;
+}
+
+.view-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 8px;
+}
+
+.back-button {
+  border: 1px solid var(--surface-border);
+  background: transparent;
+  color: var(--primary-muted);
+  border-radius: 999px;
+  width: 32px;
+  height: 32px;
+  font-size: 14px;
+  cursor: pointer;
+}
+
+.back-button:focus-visible {
+  outline: 2px solid rgba(147, 197, 253, 0.4);
+  outline-offset: 2px;
+}
+
+.view-label {
+  font-size: 12px;
+  color: var(--primary-muted);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.command-body {
+  max-height: 360px;
+  overflow: auto;
 }
 
 .snippet-panel__note {
@@ -220,16 +192,6 @@ body {
   font-size: 12px;
   color: #94a3b8;
   padding: 12px 4px;
-}
-
-.creation-panel,
-.editor-panel {
-  border-top: 1px solid rgba(148, 163, 184, 0.25);
-  padding-top: 14px;
-}
-
-.editor-panel {
-  margin-top: 12px;
 }
 
 .snippet-form {

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -9,7 +9,9 @@ describe('App', () => {
     const user = userEvent.setup()
     render(<App />)
 
-    // Wait for form to become ready
+    const searchInput = screen.getByPlaceholderText(/スニペットを検索/)
+    await user.type(searchInput, '/create')
+
     const titleInput = await screen.findByLabelText('タイトル *')
 
     await user.type(titleInput, 'Env loader snippet')
@@ -20,9 +22,9 @@ describe('App', () => {
 
     await screen.findByText('スニペットを追加しました: Env loader snippet')
 
-    const searchInput = screen.getByPlaceholderText('Search snippets…')
-    await user.clear(searchInput)
-    await user.type(searchInput, 'Env loader snippet')
+    const searchInputAfter = screen.getByPlaceholderText(/スニペットを検索/)
+    await user.clear(searchInputAfter)
+    await user.type(searchInputAfter, 'Env loader snippet')
 
     await waitFor(() =>
       expect(
@@ -36,6 +38,8 @@ describe('App', () => {
   it('allows editing an existing snippet from the editor form', async () => {
     const user = userEvent.setup()
     render(<App />)
+
+    await user.keyboard('{Control>}{Enter}{/Control}')
 
     const editTitle = await screen.findByLabelText('タイトル (編集) *')
     await waitFor(() => expect(editTitle).toHaveValue('ログ出力（Python）'))
@@ -55,12 +59,14 @@ describe('App', () => {
     const user = userEvent.setup()
     render(<App />)
 
+    await user.keyboard('{Control>}{Enter}{/Control}')
+
     const deleteButton = await screen.findByRole('button', { name: 'スニペットを削除' })
     await user.click(deleteButton)
 
     await screen.findByText('スニペットを削除しました: ログ出力（Python）')
 
-    const searchInput = screen.getByPlaceholderText('Search snippets…')
+    const searchInput = screen.getByPlaceholderText(/スニペットを検索/)
     await user.type(searchInput, 'ログ出力')
 
     await waitFor(() => {


### PR DESCRIPTION
## 概要
- 検索ビューをコマンドパレット化し、ヘッダーやフォーム、フィルタを撤去して検索バー＋結果リストのみを表示
- `/create` を入力すると追加フォーム専用ビューに遷移し、完了後は自動で検索ビューへ戻る。Cmd/Ctrl+Enter で現在選択中スニペットの編集ビューを開く
- 検索ビュー以外では左上の矢印ボタンおよび ESC で戻れるようにし、Notification などは従来どおり維持
- UI に合わせたスタイル調整と App.test.tsx の期待値更新（/create, Cmd+Enter フロー対応）

## 影響範囲
- `App.tsx` / `App.css` / `App.test.tsx`

## 関連 Issue
- Closes #103

## テスト
- `npm run test`
