### PR TITLE
feat: フレームレス検索ビューと検索欄の拡大

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -14,7 +14,8 @@
       {
         "title": "codespark",
         "width": 800,
-        "height": 600
+        "height": 600,
+        "decorations": false
       }
     ],
     "security": {

--- a/src/App.css
+++ b/src/App.css
@@ -27,7 +27,7 @@
 body {
   margin: 0;
   min-height: 100vh;
-  background: radial-gradient(circle at top, #1e293b, #020617);
+  background: #050915;
   color: #e5e7eb;
 }
 
@@ -36,31 +36,31 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 24px;
+  padding: 0;
 }
 
 .command-surface {
-  width: 680px;
-  max-width: 95vw;
+  width: 760px;
+  max-width: 96vw;
   display: flex;
   flex-direction: column;
-  gap: 16px;
-  padding: 18px 22px 16px;
-  border-radius: 20px;
-  border: 1px solid var(--surface-border);
-  background: var(--surface);
-  box-shadow: 0 32px 80px rgba(0, 0, 0, 0.65);
-  backdrop-filter: blur(10px);
+  gap: 12px;
+  padding: 10px 12px;
+  border-radius: 14px;
+  border: none;
+  background: transparent;
+  box-shadow: none;
+  backdrop-filter: none;
 }
 
 .search-bar {
   display: flex;
   align-items: center;
   gap: 10px;
-  padding: 6px 12px;
-  border-radius: 14px;
-  border: 1px solid rgba(55, 65, 81, 0.9);
-  background: rgba(2, 6, 23, 0.9);
+  padding: 12px 16px;
+  border-radius: 16px;
+  border: 1px solid rgba(55, 65, 81, 0.8);
+  background: rgba(2, 6, 23, 0.85);
 }
 
 .search-bar__input {
@@ -69,11 +69,12 @@ body {
   border: none;
   outline: none;
   color: inherit;
-  font-size: 14px;
+  font-size: 16px;
+  font-weight: 500;
 }
 
 .snippet-panel {
-  max-height: 320px;
+  max-height: 420px;
   overflow: auto;
   display: flex;
   flex-direction: column;
@@ -81,7 +82,13 @@ body {
 }
 
 .command-surface--panel {
-  width: 720px;
+  width: 760px;
+  max-width: 96vw;
+  padding: 18px 22px 16px;
+  border: 1px solid var(--surface-border);
+  background: var(--surface);
+  box-shadow: 0 32px 80px rgba(0, 0, 0, 0.65);
+  backdrop-filter: blur(10px);
 }
 
 .view-toolbar {


### PR DESCRIPTION
# 🚀 Pull Request

## 📝 概要（Summary）
検索ビューをフレームレス化し、検索欄を拡大してシンプルなコマンドパレット見た目に寄せます。

---

## 🔍 変更内容（What’s Changed）
- Tauri ウィンドウの `decorations` を `false` にしてタイトルバー（赤黄緑ボタン）を非表示化
- 検索ビューのレイアウトを簡素化し、背景/枠/影を排除したフラットな表示に調整
- 検索欄の幅を最大化し、高さとフォントサイズを拡大（現行比 1.2〜1.4 倍目安）
- 非検索ビュー（/create /list /settings 等）は既存のパネルスタイルを維持

---

## 📚 背景・理由（Why）
- Closes #113
- Raycast/PowerToys のように余白の少ない検索ビューとフレームレス表示を求められたため

---

## 🧪 動作確認（How to Test）
```bash
npm run test
npm run build
cd src-tauri && cargo test
```
- macOS で `npm run tauri dev` を起動し、タイトルバーが消えていること、検索欄が拡大されていることを目視確認
- ショートカット（Enter コピー、Cmd/Ctrl+Enter アクションパレット、↑↓/Cmd+J,K 移動）が従来どおり動くことを手動確認

* [x] テストコードを追加した（必要な場合なし）
* [x] 既存テストがすべて通っている

---

## 📦 影響範囲（Impact）
* [ ] API
* [x] UI
* [ ] データベース
* [x] 設定ファイル（tauri.conf.json: decorations 変更）
* [ ] その他（記述）

---

## ❗️ Breaking Changes（破壊的変更）
* なし

---

## 📝 補足（Notes）
- 非検索ビューの見た目はパネルスタイルを維持し、検索ビューのみフラット化しています。
